### PR TITLE
SQ-32 Test Sf 15.2 with uCommerce

### DIFF
--- a/SitefinityWebApp.csproj
+++ b/SitefinityWebApp.csproj
@@ -6,7 +6,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <Use64BitIISExpress />
-    <IISExpressSSLPort />
+    <IISExpressSSLPort>44390</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
@@ -37,7 +37,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkProfile />
-    <UseIISExpress>false</UseIISExpress>
+    <UseIISExpress>true</UseIISExpress>
     <DisableOutOfProcTask>True</DisableOutOfProcTask>
     <VisualStudioVersion>11.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
No Code changes required. uCommerce 9.7.0.23075 works out of the box.

- Only made changes to use IISExpress and add in an SSL port as without these, the site cannot be launched

As mentioned previously, This version of uCommerce requires the database compatability version to be at least 130 otherwise the site will fail to index and the uCommerce functionality will not work as expected.